### PR TITLE
🔧(github): Simplify documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/doc_issue.yml
+++ b/.github/ISSUE_TEMPLATE/doc_issue.yml
@@ -1,0 +1,35 @@
+name: Documentation Issue
+description: Report an issue or suggest improvements to Lupa's documentation
+labels:
+  - documentation
+body:
+  - type: checkboxes
+    attributes:
+      label: Self Check
+      options:
+        - label: I have searched for [existing issues](https://github.com/crafter-station/lupa/issues), including closed ones
+          required: true
+
+  - type: input
+    attributes:
+      label: Documentation Page
+      description: Which page or section has the issue?
+      placeholder: e.g., README.md, AGENTS.md, /docs API reference
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Issue Description
+      description: What's wrong or what needs improvement?
+      placeholder: Describe the issue clearly and concisely
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Suggested Fix
+      description: How should it be improved? (optional but helpful)
+      placeholder: Provide your suggested changes or improvements
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+## Issue
+
+- resolve:
+
+## Why is this change needed?
+<!-- Please explain briefly why this change is necessary -->


### PR DESCRIPTION
## Issue #24  
- resolve: N/A (Internal improvement)

## Why is this change needed?
This change simplifies the GitHub documentation issue template