### PR TITLE
Add GitHub issue templates and automated issue creation command

### DIFF
--- a/.github/ISSUE_TEMPLATE/api_issue.yml
+++ b/.github/ISSUE_TEMPLATE/api_issue.yml
@@ -1,0 +1,77 @@
+name: API Issue
+description: Report an issue with the Lupa API
+labels:
+  - api
+  - bug
+body:
+  - type: checkboxes
+    attributes:
+      label: Self Check
+      options:
+        - label: I have searched for [existing issues](https://github.com/crafter-station/lupa/issues), including closed ones
+          required: true
+
+  - type: input
+    attributes:
+      label: API Endpoint
+      description: Which endpoint is affected?
+      placeholder: e.g., POST /api/chat, GET /api/collections/[id]
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Request Details
+      description: Provide the request you're making
+      placeholder: |
+        Method: POST
+        URL: /api/search
+        Headers: { ... }
+        Body: { ... }
+      render: json
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected Response
+      description: What response did you expect?
+      placeholder: Describe the expected behavior or response
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Actual Response
+      description: What response did you actually receive?
+      placeholder: |
+        Status: 500
+        Body: { "error": "..." }
+      render: json
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Error Logs/Traces
+      description: Include any error messages, stack traces, or logs
+      placeholder: Paste error logs here
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: SDK/Client Version
+      description: If using an SDK or client, which version?
+      placeholder: e.g., @lupa/sdk@1.2.3, curl, fetch
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem
+      placeholder: Rate limiting, authentication, specific project, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/general_issue.yml
+++ b/.github/ISSUE_TEMPLATE/general_issue.yml
@@ -1,0 +1,64 @@
+name: General Issue
+description: Report a general issue, feature request, or question
+labels:
+  - triage
+body:
+  - type: checkboxes
+    attributes:
+      label: Self Check
+      options:
+        - label: I have searched for [existing issues](https://github.com/crafter-station/lupa/issues), including closed ones
+          required: true
+
+  - type: dropdown
+    attributes:
+      label: Issue Type
+      description: What type of issue is this?
+      options:
+        - Feature Request
+        - Enhancement
+        - Question
+        - Discussion
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Subject
+      description: Brief summary of your issue
+      placeholder: e.g., Add support for PDF parsing, Improve search performance
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: Provide details about your issue, request, or question
+      placeholder: Describe your issue, feature request, or question in detail
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Use Case/Motivation
+      description: Why is this important? What problem does it solve?
+      placeholder: Explain the use case or motivation behind this issue
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Proposed Solution
+      description: How would you like to see this addressed?
+      placeholder: Describe your proposed solution or approach
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: Any other context, links, or references
+      placeholder: Add any other context, screenshots, or links
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/webapp_issue.yml
+++ b/.github/ISSUE_TEMPLATE/webapp_issue.yml
@@ -1,0 +1,64 @@
+name: Web App Issue
+description: Report a bug or issue with the Lupa web application (lupa.build)
+labels:
+  - web-app
+  - bug
+body:
+  - type: checkboxes
+    attributes:
+      label: Self Check
+      options:
+        - label: I have searched for [existing issues](https://github.com/crafter-station/lupa/issues), including closed ones
+          required: true
+
+  - type: input
+    attributes:
+      label: Browser & Version
+      description: Which browser are you using?
+      placeholder: e.g., Chrome 120, Firefox 121, Safari 17
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Page/Feature
+      description: Which page or feature is affected?
+      placeholder: e.g., /orgs/[slug]/projects, Chat interface, File upload
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Bug Description
+      description: What happened? What did you expect to happen?
+      placeholder: Describe the issue clearly and concisely
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Screenshots/Logs
+      description: Add screenshots or console logs if applicable
+      placeholder: Paste screenshots or error messages here
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem
+      placeholder: Environment, account type, specific project, etc.
+    validations:
+      required: false

--- a/.opencode/command/create-issue.md
+++ b/.opencode/command/create-issue.md
@@ -1,0 +1,30 @@
+---
+description: Create GitHub issue following templates
+agent: plan
+---
+
+Create a GitHub issue for Lupa following our templates.
+
+Templates: @.github/ISSUE_TEMPLATE/webapp_issue.yml @.github/ISSUE_TEMPLATE/api_issue.yml @.github/ISSUE_TEMPLATE/doc_issue.yml @.github/ISSUE_TEMPLATE/general_issue.yml
+
+The user will call this command with their issue description as an argument (e.g., "/create-issue I found it necessary to have read-only API keys").
+
+Based on the user's description:
+1. Determine which template fits best (webapp, api, doc, or general)
+2. Extract as much information as possible from their description
+3. Only ask for additional required fields that cannot be inferred
+4. Generate the complete issue ready to copy/paste to GitHub
+
+Format the output as:
+```
+Title: [Generated title]
+Labels: [Comma-separated labels]
+
+---
+
+[Complete issue body in GitHub markdown format with all fields filled]
+```
+
+Be concise - if you can infer the information, don't ask. The goal is to make issue creation as fast as possible.
+
+User input: $ARGUMENTS


### PR DESCRIPTION
## Summary

• Add structured GitHub issue templates for API, web app, and general
issues to standardize bug reporting and feature requests
• Add OpenCode command /create-issue to automate issue creation by
inferring the appropriate template and extracting information from
user input

## Issue 

#32 

[LUP-551](https://linear.app/crafter-station/issue/LUP-551/add-opencode-command-to-create-linear-issues-from-terminal)