### PR TITLE
docs: add contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 
 Lupa is a production-ready RAG (Retrieval-Augmented Generation) infrastructure that gives AI agents instant access to your knowledge base. Built with semantic search, intelligent document parsing, and real-time observability.
 
-🔍 **Semantic Search**: pgvector-powered retrieval with <50ms P95 latency  
+## Contributors
+
+<a href="https://github.com/crafter-station/lupa/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=crafter-station/lupa" />
+</a>
+
+🔍 **Semantic Search**: pgvector-powered retrieval with <50ms P95 latency
 📄 **Smart Parsing**: Automatic chunking for PDF, DOCX, XLSX, CSV, HTML, and more  
 📊 **Agent Observability**: Track queries, relevance scores, and retrieval patterns  
 🔄 **Version Control**: Snapshot-based deployments with zero-downtime updates  


### PR DESCRIPTION
## Closes #35 

## Issue

- resolve: N/A (documentation enhancement)

## Why is this change needed?

This change adds a Contributors section to the README to acknowledge and showcase all the developers who have
contributed to the Lupa project. The section includes a visual contributor gallery powered by contrib.rocks,
which automatically displays contributor avatars from GitHub's contributor graph.

This enhancement improves project transparency and encourages community participation by publicly recognizing
contributors' work.

## Changes

- Added Contributors section below the project description
- Integrated contrib.rocks badge that dynamically displays all contributors
- Minor formatting adjustment to feature list spacing